### PR TITLE
Really truly support all rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 1.9.3
   - jruby
   - 1.8.7
-  - rbx-2.0
+  - rbx-19mode
   - rbx-18mode
   - ruby-head
   - ree


### PR DESCRIPTION
rbx and rbx-2.0 are just aliases for rbx-18mode
